### PR TITLE
Updating App Domain Unloading Info

### DIFF
--- a/Documents/appdomainsunloaded/solution.md
+++ b/Documents/appdomainsunloaded/solution.md
@@ -4,12 +4,14 @@
 ```
 <system.web>
   <customErrors mode="Off" />
-  <rules>
-    <add name="Application Events"
-         eventName="Application Lifetime Events"
-         provider="EventLogProvider"
-         profile="Default"
-         minInterval="00:01:00" />
-  </rules>
+  <healthMonitoring>
+    <rules>
+      <add name="Application Events"
+          eventName="Application Lifetime Events"
+          provider="EventLogProvider"
+          profile="Default"
+          minInterval="00:01:00" />
+    </rules>
+  </healthMonitoring>
 </system.web>
 ```


### PR DESCRIPTION
Seems that the previous information was malformed and causing 500.19 errors.
This is taken from this blog: https://blogs.msdn.microsoft.com/tess/2006/08/02/asp-net-case-study-lost-session-variables-and-appdomain-recycles/
 

How do you determine what caused an appdomain restart? 


 

In ASP.NET 2.0 you can use the built in Health Monitoring Events to log application restarts along with the reason for the restart.  To do this you change the master web.config file in the C:WINDOWSMicrosoft.NETFrameworkv2.0.50727CONFIG directory and add the following to the <healthMonitoring><rules> section 


 

                <add name=“Application Lifetime Events Default“ eventName=“Application Lifetime Events“ 

                    provider=“EventLogProvider“ profile=“Default“ minInstances=“1“